### PR TITLE
Handle NoRecordsMatch exception

### DIFF
--- a/harvester/cli.py
+++ b/harvester/cli.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 
+from datetime import date, timedelta
+import logging
+import sys
+
+import click
 from sickle import Sickle
 from sickle.iterator import OAIItemIterator
 from sickle.oaiexceptions import NoRecordsMatch
-import logging
-from datetime import date, timedelta
-import click
 from smart_open import open
-import sys
 
 yesterday = (date.today() - timedelta(days=1)).strftime('%Y-%m-%d')
 tomorrow = (date.today() + timedelta(days=1)).strftime('%Y-%m-%d')

--- a/harvester/cli.py
+++ b/harvester/cli.py
@@ -2,6 +2,7 @@
 
 from sickle import Sickle
 from sickle.iterator import OAIItemIterator
+from sickle.oaiexceptions import NoRecordsMatch
 import logging
 from datetime import date, timedelta
 import click
@@ -42,12 +43,17 @@ def harvest(host, from_date, until, format, out, verbose):
 
     mysickle = Sickle(host, iterator=OAIItemIterator)
 
-    responses = mysickle.ListRecords(
-        **{'metadataPrefix': format,
-           # 'set': 'hdl_1721.1_33972'
-           'from': from_date,
-           'until': until
-           })
+    try:
+        responses = mysickle.ListRecords(
+            **{'metadataPrefix': format,
+               # 'set': 'hdl_1721.1_33972'
+               'from': from_date,
+               'until': until
+               })
+    except NoRecordsMatch:
+        logging.info("No records harvested: the combination of the values of "
+                     "the arguments results in an empty list.")
+        exit()
 
     with open(out, 'wb') as f:
         f.write('<records>'.encode())
@@ -60,8 +66,6 @@ def harvest(host, from_date, until, format, out, verbose):
         f.write('</records>'.encode())
 
     logging.info("Total records: %i", counter)
-
-    exit(0)
 
 
 if __name__ == "__main__":

--- a/harvester/cli.py
+++ b/harvester/cli.py
@@ -7,6 +7,7 @@ import logging
 from datetime import date, timedelta
 import click
 from smart_open import open
+import sys
 
 yesterday = (date.today() - timedelta(days=1)).strftime('%Y-%m-%d')
 tomorrow = (date.today() + timedelta(days=1)).strftime('%Y-%m-%d')
@@ -53,7 +54,7 @@ def harvest(host, from_date, until, format, out, verbose):
     except NoRecordsMatch:
         logging.info("No records harvested: the combination of the values of "
                      "the arguments results in an empty list.")
-        exit()
+        sys.exit()
 
     with open(out, 'wb') as f:
         f.write('<records>'.encode())


### PR DESCRIPTION
This is a likely normal case so we just log what happened and exit rather than throwing the exception.

closes #18 