### PR TITLE
Add workflow to publish to ECR, modify dockerfile and makefile

### DIFF
--- a/.github/workflows/dev_ecr_push.yml
+++ b/.github/workflows/dev_ecr_push.yml
@@ -1,0 +1,37 @@
+name: dev ECR push
+on:
+  push:
+    branches:
+      - main
+# Set defaults
+defaults:
+  run:
+    shell: bash
+
+env:
+  AWS_REGION: "us-east-1"
+  AWS_ACCOUNT_ID: "222053980223"
+  IAM_ROLE: "timdex-transmogrifier-gha-dev"
+
+jobs:
+  deploy:
+    name: Deploy dev build
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ env.IAM_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Build image
+        run: make dist-dev
+      - name: Push image
+        run: make publish-dev
+

--- a/.github/workflows/dev_ecr_push.yml
+++ b/.github/workflows/dev_ecr_push.yml
@@ -11,7 +11,7 @@ defaults:
 env:
   AWS_REGION: "us-east-1"
   AWS_ACCOUNT_ID: "222053980223"
-  IAM_ROLE: "timdex-transmogrifier-gha-dev"
+  IAM_ROLE: "timdex-oaiharvester-gha-dev"
 
 jobs:
   deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3 AS py3
+FROM python:3.10-slim AS py3
 RUN pip install pipenv
 
 FROM py3 AS wheel

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test lint dist update publish promote
+.PHONY: install test coveralls lint bandit black flake8 isort mypy update dist-dev update publish-dev
 SHELL=/bin/bash
 ECR_REGISTRY=222053980223.dkr.ecr.us-east-1.amazonaws.com
 DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ make install
 To build and run in docker:
 
 ```bash
-make dist
+make dist-dev
 docker run -it oaiharvester
 ```
 


### PR DESCRIPTION
#### Helpful background context
This commit adds the workflow to automatically publish images on pushes to the main branch.
I update the dockerfile to use the 3.10-slim image, which more closely matches how we do other python dockerfiles.
i update the makefile to have two dev specific commands, "dist-dev" which creates the docker image locally and "publish-dev" which then publishes it to the dev ECR for use in stepfunctions.

#### How can a reviewer manually see the effects of these changes?
To test, i did a local publish-dev from my machine which was successful in building and publishing an image.  I didn't test the image however.  

#### Includes new or updated dependencies?
NO

#### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/RDI-72

#### Developer
- [NA] All new ENV is documented in README
- [NA] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes