### PR TITLE
Update workflows and makefile

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,5 +1,5 @@
 ### This is the Terraform-generated dev-build.yml workflow for the oai-pmh-harvester-dev app repository ###
-name: dev Build and Deploy Fargate Container
+name: Dev Build and Deploy Fargate Container
 on:
   workflow_dispatch:
   pull_request:
@@ -10,8 +10,8 @@ on:
 
 jobs:
   deploy:
-    name: dev Deploy Fargate Container
-    uses: mitlibraries/.github/.github/workflows/fargate-shared-deploy-dev.yml@container-flows
+    name: Dev Deploy Fargate Container
+    uses: mitlibraries/.github/.github/workflows/fargate-shared-deploy-dev.yml@main
     secrets: inherit
     with:
       AWS_REGION: "us-east-1"

--- a/.github/workflows/prod-promote.yml
+++ b/.github/workflows/prod-promote.yml
@@ -1,0 +1,18 @@
+### This is the Terraform-generated prod-promote.yml workflow for the oai-pmh-harvester-prod app repository ###
+name: Prod Promote Fargate Container
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    name: Prod Promote Fargate Container
+    uses: mitlibraries/.github/.github/workflows/fargate-shared-promote-prod.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE_STAGE: oai-pmh-harvester-gha-stage
+      GHA_ROLE_PROD: oai-pmh-harvester-gha-prod
+      ECR_STAGE: "oai-pmh-harvester-stage"
+      ECR_PROD: "oai-pmh-harvester-prod"

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -1,5 +1,5 @@
 ### This is the Terraform-generated stage-build.yml workflow for the oai-pmh-harvester-stage app repository ###
-name: stage Build and Deploy Fargate Container
+name: Stage Build and Deploy Fargate Container
 on:
   workflow_dispatch:
   push:
@@ -10,8 +10,8 @@ on:
 
 jobs:
   deploy:
-    name: stage Deploy Fargate Container
-    uses: mitlibraries/.github/.github/workflows/fargate-shared-deploy-stage.yml@container-flows
+    name: Stage Deploy Fargate Container
+    uses: mitlibraries/.github/.github/workflows/fargate-shared-deploy-stage.yml@main
     secrets: inherit
     with:
       AWS_REGION: "us-east-1"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: install test coveralls lint bandit black flake8 isort mypy update dist-dev update publish-dev
+.PHONY: install test coveralls lint bandit black flake8 isort mypy dist-dev update publish-dev
 SHELL=/bin/bash
 DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
-### This is the Terraform-generated header for oai-pmh-harvester-dev
+### This is the Terraform-generated header for oai-pmh-harvester-dev ###
 ECR_NAME_DEV:=oai-pmh-harvester-dev
 ECR_URL_DEV:=222053980223.dkr.ecr.us-east-1.amazonaws.com/oai-pmh-harvester-dev
 ### End of Terraform-generated header ###
@@ -42,7 +42,7 @@ update: install ## Update all Python dependencies
 	pipenv clean
 	pipenv update --dev
 
-### Developer Deploy Commands ###
+### Terraform-generated Developer Deploy Commands for Dev environment ###
 dist-dev: ## Build docker container (intended for developer-based manual build)
 	docker build --platform linux/amd64 \
 	    -t $(ECR_URL_DEV):latest \
@@ -53,3 +53,18 @@ publish-dev: dist-dev ## Build, tag and push (intended for developer-based manua
 	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_DEV)
 	docker push $(ECR_URL_DEV):latest
 	docker push $(ECR_URL_DEV):`git describe --always`
+
+### Terraform-generated manual shortcuts for deploying to Stage ###
+### This requires that ECR_NAME_STAGE & ECR_URL_STAGE environment variables are set locally
+### by the developer and that the developer has authenticated to the correct AWS Account.
+### The values for the environment variables can be found in the stage_build.yml caller workflow.
+dist-stage: ## Only use in an emergency
+	docker build --platform linux/amd64 \
+	    -t $(ECR_URL_STAGE):latest \
+		-t $(ECR_URL_STAGE):`git describe --always` \
+		-t $(ECR_NAME_STAGE):latest .
+
+publish-stage: ## Only use in an emergency
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_STAGE)
+	docker push $(ECR_URL_STAGE):latest
+	docker push $(ECR_URL_STAGE):`git describe --always`


### PR DESCRIPTION
Now that we have landed on a final version of workflows and makefiles for our projects, I need to do 1 more revision of the Workflows and makefile.

This sets up/refines all workflows and the makefile

It adds the prod promote workflow, which will not work until we deploy prod

This is a copy/paste from the ECR infrastructure output, this output is available to the devs in terraform cloud.
