### PR TITLE
Update sentry and logging configuration

### DIFF
--- a/harvester/config.py
+++ b/harvester/config.py
@@ -1,0 +1,34 @@
+"""transmogrifier.config module."""
+import logging
+import os
+
+import sentry_sdk
+
+
+def configure_logger(logger: logging.Logger, verbose: bool) -> str:
+    if verbose:
+        logging.basicConfig(
+            format="%(asctime)s %(levelname)s %(name)s.%(funcName)s() line %(lineno)d: "
+            "%(message)s"
+        )
+        logger.setLevel(logging.DEBUG)
+        for handler in logging.root.handlers:
+            handler.addFilter(logging.Filter("harvester"))
+    else:
+        logging.basicConfig(
+            format=("%(asctime)s %(levelname)s %(name)s.%(funcName)s(): %(message)s")
+        )
+        logger.setLevel(logging.INFO)
+    return (
+        f"Logger '{logger.name}' configured with level="
+        f"{logging.getLevelName(logger.getEffectiveLevel())}"
+    )
+
+
+def configure_sentry() -> str:
+    env = os.getenv("WORKSPACE")
+    sentry_dsn = os.getenv("SENTRY_DSN")
+    if sentry_dsn and sentry_dsn.lower() != "none":
+        sentry_sdk.init(sentry_dsn, environment=env)
+        return f"Sentry DSN found, exceptions will be sent to Sentry with env={env}"
+    return "No Sentry DSN found, exceptions will not be sent to Sentry"

--- a/harvester/config.py
+++ b/harvester/config.py
@@ -1,4 +1,4 @@
-"""transmogrifier.config module."""
+"""harvester.config module."""
 import logging
 import os
 

--- a/harvester/oai.py
+++ b/harvester/oai.py
@@ -74,8 +74,12 @@ def write_records(records: Iterator, filepath: str) -> int:
     with smart_open.open(filepath, "wb") as file:
         file.write("<records>\n".encode())
         for record in records:
-            count += 1
             file.write("  ".encode() + record.raw.encode() + "\n".encode())
+            count += 1
+            if count % 1000 == 0:
+                logger.info(
+                    "Status update: %s records written to output file so far!", count
+                )
         file.write("</records>".encode())
     return count
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,6 @@ ignore_missing_imports = True
 
 [mypy-smart_open.*]
 ignore_missing_imports = True
+
+[tool:pytest]
+log_level = DEBUG

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,13 @@
+import os
+
 import pytest
 from click.testing import CliRunner
+
+
+@pytest.fixture(autouse=True)
+def test_env():
+    os.environ = {"WORKSPACE": "test"}
+    yield
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,3 @@
-import logging
-
 import vcr
 
 from harvester.cli import main
@@ -8,8 +6,6 @@ from harvester.cli import main
 @vcr.use_cassette("tests/fixtures/vcr_cassettes/get-records-exclude-deleted.yaml")
 def test_harvest_all_options_except_set_spec(caplog, monkeypatch, cli_runner, tmp_path):
     monkeypatch.setenv("SENTRY_DSN", "https://1234567890@00000.ingest.sentry.io/123456")
-    monkeypatch.setenv("WORKSPACE", "test")
-    caplog.set_level(logging.DEBUG)
     with cli_runner.isolated_filesystem(temp_dir=tmp_path):
         filepath = tmp_path / "records.xml"
         result = cli_runner.invoke(
@@ -31,6 +27,8 @@ def test_harvest_all_options_except_set_spec(caplog, monkeypatch, cli_runner, tm
             ],
         )
         assert result.exit_code == 0
+
+        assert "Logger 'root' configured with level=DEBUG" in caplog.text
         assert (
             "Sentry DSN found, exceptions will be sent to Sentry with env=test"
             in caplog.text
@@ -56,7 +54,6 @@ def test_harvest_all_options_except_set_spec(caplog, monkeypatch, cli_runner, tm
 
 @vcr.use_cassette("tests/fixtures/vcr_cassettes/harvest-from-set.yaml")
 def test_harvest_no_options_except_set_spec(caplog, cli_runner, tmp_path):
-    caplog.set_level(logging.INFO)
     with cli_runner.isolated_filesystem(temp_dir=tmp_path):
         filepath = tmp_path / "records.xml"
         result = cli_runner.invoke(
@@ -72,6 +69,10 @@ def test_harvest_no_options_except_set_spec(caplog, cli_runner, tmp_path):
             ],
         )
         assert result.exit_code == 0
+        assert "Logger 'root' configured with level=INFO" in caplog.text
+        assert (
+            "No Sentry DSN found, exceptions will not be sent to Sentry" in caplog.text
+        )
         assert (
             "OAI-PMH harvesting from source https://dspace.mit.edu/oai/request with "
             "parameters: metadata_format=oai_dc, from_date=None, until_date="

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,35 @@
+import logging
+
+from harvester.config import configure_logger, configure_sentry
+
+
+def test_configure_logger_not_verbose():
+    logger = logging.getLogger(__name__)
+    result = configure_logger(logger, verbose=False)
+    assert logger.getEffectiveLevel() == 20
+    assert result == "Logger 'test_config' configured with level=INFO"
+
+
+def test_configure_logger_verbose(caplog):
+    logger = logging.getLogger(__name__)
+    result = configure_logger(logger, verbose=True)
+    assert logger.getEffectiveLevel() == 10
+    assert result == "Logger 'test_config' configured with level=DEBUG"
+
+
+def test_configure_sentry_no_env_variable(monkeypatch):
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    result = configure_sentry()
+    assert result == "No Sentry DSN found, exceptions will not be sent to Sentry"
+
+
+def test_configure_sentry_env_variable_is_none(monkeypatch):
+    monkeypatch.setenv("SENTRY_DSN", "None")
+    result = configure_sentry()
+    assert result == "No Sentry DSN found, exceptions will not be sent to Sentry"
+
+
+def test_configure_sentry_env_variable_is_dsn(monkeypatch):
+    monkeypatch.setenv("SENTRY_DSN", "https://1234567890@00000.ingest.sentry.io/123456")
+    result = configure_sentry()
+    assert result == "Sentry DSN found, exceptions will be sent to Sentry with env=test"


### PR DESCRIPTION
#### Helpful background context
Our terraform template requires that each env variable be present in all envs, even if we don't need it in a particular env (e.g. `SENTRY_DSN` is not needed in dev). Terraform now assigns env variables a string value of "None" in env(s) where they are not needed.

In addition, while working on that a logging bug was addressed in which logging was configured on the cli module logger instead of the root logger and thus was not propagating to all modules. In resolving both issues it made sense to refactor these configuration steps into their own functions in a separate config module.

#### How can a reviewer manually see the effects of these changes?
For sentry configuration:
- In .env, set `SENTRY_DSN=None` and run a harvest to observe that Sentry is not configured and no exception is raised (which would happen if you passed sentry's `init` a value of "None").

For logging configuration and updates:
- Run a harvest and observe that logging is configured and the log output includes the total harvest time and status updates every 1000 records.

Sample command to run a small harvest that will pull just over 1000 records from DSpace@MIT (you may need to `make install` if you haven't run this locally in a while):
```pipenv run oai -h https://dspace.mit.edu/oai/request -o output/dspace-sample-harvest.xml harvest -m mets -f 2022-05-26```

#### Includes new or updated dependencies?
NO

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/RDI-15
- https://mitlibraries.atlassian.net/browse/RDI-127

#### Developer
- [x] All new ENV is documented in README
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes