### PR TITLE
RDI-115-retry-logic

### DIFF
--- a/harvester/config.py
+++ b/harvester/config.py
@@ -4,6 +4,10 @@ import os
 
 import sentry_sdk
 
+DEFAULT_RETRY_AFTER = 10
+MAX_RETRIES = 3
+RETRY_STATUS_CODES = (429, 500, 503)
+
 
 def configure_logger(logger: logging.Logger, verbose: bool) -> str:
     if verbose:

--- a/harvester/oai.py
+++ b/harvester/oai.py
@@ -7,6 +7,8 @@ import smart_open
 from sickle import Sickle
 from sickle.models import Record
 
+from harvester.config import DEFAULT_RETRY_AFTER, MAX_RETRIES, RETRY_STATUS_CODES
+
 logger = logging.getLogger(__name__)
 
 
@@ -20,7 +22,12 @@ class OAIClient:
         set_spec: Optional[str] = None,
     ) -> None:
         self.source_url = source_url
-        self.client = Sickle(self.source_url)
+        self.client = Sickle(
+            self.source_url,
+            default_retry_after=DEFAULT_RETRY_AFTER,
+            max_retries=MAX_RETRIES,
+            retry_status_codes=RETRY_STATUS_CODES,
+        )
         self.metadata_format = metadata_format
         self._set_params(metadata_format, from_date, until_date, set_spec)
 


### PR DESCRIPTION
#### How can a reviewer manually see the effects of these changes?
Run a large harvest to increase the chances of an error being caught, I received a few 500 errors from DSpace and the harvest continued.

```
pipenv run oai -h https://dspace.mit.edu/oai/request -o output/dspace-sample-harvest.xml harvest -m mets -f 2022-01-26
```

#### Includes new or updated dependencies?
NO

#### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/RDI-115

#### Developer
- [x] All new ENV is documented in README
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes