### PR TITLE
Update To New Tf Workflows

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,5 +1,8 @@
 ### This is the Terraform-generated dev-build.yml workflow for the oai-pmh-harvester-dev app repository ###
-name: Dev Build and Deploy Fargate Container
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document     ###
+### If the container requires any additional pre-build commands, uncomment and edit      ###
+### the PREBUILD line at the end of the document.                                        ###
+name: Dev Container Build and Deploy
 on:
   workflow_dispatch:
   pull_request:
@@ -10,10 +13,12 @@ on:
 
 jobs:
   deploy:
-    name: Dev Deploy Fargate Container
-    uses: mitlibraries/.github/.github/workflows/fargate-shared-deploy-dev.yml@main
+    name: Dev Container Deploy
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-deploy-dev.yml@main
     secrets: inherit
     with:
       AWS_REGION: "us-east-1"
       GHA_ROLE: "oai-pmh-harvester-gha-dev"
       ECR: "oai-pmh-harvester-dev"
+      # FUNCTION: ""
+      # PREBUILD: 

--- a/.github/workflows/prod-promote.yml
+++ b/.github/workflows/prod-promote.yml
@@ -1,5 +1,6 @@
-### This is the Terraform-generated prod-promote.yml workflow for the oai-pmh-harvester-prod app repository ###
-name: Prod Promote Fargate Container
+### This is the Terraform-generated prod-promote.yml workflow for the oai-pmh-harvester-prod repository. ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document.         ###
+name: Prod Container Promote
 on:
   workflow_dispatch:
   release:
@@ -7,8 +8,8 @@ on:
 
 jobs:
   deploy:
-    name: Prod Promote Fargate Container
-    uses: mitlibraries/.github/.github/workflows/fargate-shared-promote-prod.yml@main
+    name: Prod Container Promote
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-promote-prod.yml@main
     secrets: inherit
     with:
       AWS_REGION: "us-east-1"
@@ -16,3 +17,5 @@ jobs:
       GHA_ROLE_PROD: oai-pmh-harvester-gha-prod
       ECR_STAGE: "oai-pmh-harvester-stage"
       ECR_PROD: "oai-pmh-harvester-prod"
+      # FUNCTION: ""
+ 

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -1,5 +1,8 @@
-### This is the Terraform-generated stage-build.yml workflow for the oai-pmh-harvester-stage app repository ###
-name: Stage Build and Deploy Fargate Container
+### This is the Terraform-generated dev-build.yml workflow for the oai-pmh-harvester-stage app repository ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document     ###
+### If the container requires any additional pre-build commands, uncomment and edit      ###
+### the PREBUILD line at the end of the document.                                        ###
+name: Stage Container Build and Deploy
 on:
   workflow_dispatch:
   push:
@@ -10,10 +13,12 @@ on:
 
 jobs:
   deploy:
-    name: Stage Deploy Fargate Container
-    uses: mitlibraries/.github/.github/workflows/fargate-shared-deploy-stage.yml@main
+    name: Stage Container Deploy
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-deploy-stage.yml@main
     secrets: inherit
     with:
       AWS_REGION: "us-east-1"
       GHA_ROLE: "oai-pmh-harvester-gha-stage"
       ECR: "oai-pmh-harvester-stage"
+      # FUNCTION: ""
+      # PREBUILD: 


### PR DESCRIPTION
### What does this PR do?

* Update three caller workflows to use the new outputs from the mitlib-tf-workloads-ecr repository
* Resolves #519 

### Helpful background context

The build/deploy workflows in our shared .github repository for Lambda functions and Fargate tasks have been cleaned up and consolidated. The mitlib-tf-workloads-ecr repository that generates the text for the three caller workflows has been updated and we just need to move those Terraform outputs into this repository to update the caller workflows.

### How can a reviewer manually see the effects of these changes?

The developer can manually trigger the `dev-build.yml` workflow (from this branch) in the Actions tab to verify that the caller workflow properly pushes the updated container to the Dev1 AWS Account. Because the changed files live in a folder that is ignored by the workflow triggers, none of the workflows should get automatically triggered. Or, the developer can review the [workflow run](https://github.com/MITLibraries/alma-webhook-lambdas/actions/runs/4428261289) that was triggered manually by me.

### Includes new or updated dependencies?

NO

### Developer

- [ ] All new ENV is documented in README
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
