### PR TITLE
Update README re: environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Additional notes:
 ```shell
 # Set to dev for local development, this will be set to 'stage' and 'prod' in those environments by Terraform.
 WORKSPACE=dev
+
+# If set to a valid Sentry DSN, enables Sentry exception monitoring. Otherwise, this should be set to 'none'.
+SENTRY_DSN=<sentry-dsn-for-oai-pmh-harvester>
 ```
 
 ### Optional
@@ -67,9 +70,6 @@ RECORD_SKIP_LIST=<oai-pmh-id1> <oai-pmh-id2>
 
 # Sets the interval for logging status updates as records are written to the output file. Defaults to 1000, which will log a status update for every thousandth record.
 STATUS_UPDATE_INTERVAL = 1000
-
-# If set to a valid Sentry DSN, enables Sentry exception monitoring This is not needed for local development.
-SENTRY_DSN = <sentry-dsn-for-oai-pmh-harvester>
 ```
 
 ## CLI commands


### PR DESCRIPTION
Updating README to reflect that a value for SENTRY_DSN is required.  When getting this running locally (sans Docker), I encountered a fatal error indicating that this environment variable was unset.  After reviewing `harvester/config.py` l.17, it became clear that it's required, and l.57 of same indicates "none" needs to be used for opt-out.

Cheers for this great OAI tool.