### PR TITLE
Remove SENTRY_DSN from required env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ WORKSPACE=dev
 RECORD_SKIP_LIST=<oai-pmh-id1> <oai-pmh-id2>
 
 # Sets the interval for logging status updates as records are written to the output file. Defaults to 1000, which will log a status update for every thousandth record.
-STATUS_UPDATE_INTERVAL = 1000
+STATUS_UPDATE_INTERVAL=1000
 
-# If set to a valid Sentry DSN, enables Sentry exception monitoring This is not needed for local development.
-SENTRY_DSN = <sentry-dsn-for-oai-pmh-harvester>
+# If set to a valid Sentry DSN, enables Sentry exception monitoring. This can also be set to 'none'.
+SENTRY_DSN=<sentry-dsn-for-oai-pmh-harvester>
 ```
 
 ## CLI commands

--- a/harvester/config.py
+++ b/harvester/config.py
@@ -14,8 +14,8 @@ MAX_ALLOWED_ERRORS = 10
 
 
 class Config:
-    REQUIRED_ENV_VARS = ("WORKSPACE", "SENTRY_DSN")
-    OPTIONAL_ENV_VARS = ("RECORD_SKIP_LIST", "STATUS_UPDATE_INTERVAL")
+    REQUIRED_ENV_VARS = ("WORKSPACE",)
+    OPTIONAL_ENV_VARS = ("RECORD_SKIP_LIST", "SENTRY_DSN", "STATUS_UPDATE_INTERVAL")
 
     def __init__(self, logger: logging.Logger | None = None):
         """Set root logger as default when creating class instance."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -51,14 +51,6 @@ def test_config_check_required_env_vars_success(config):
     config.check_required_env_vars()
 
 
-def test_config_check_required_env_vars_error(config, monkeypatch):
-    monkeypatch.delenv("SENTRY_DSN")
-    with pytest.raises(
-        OSError, match="Missing required environment variables: SENTRY_DSN"
-    ):
-        config.check_required_env_vars()
-
-
 def test_config_env_var_access_success(config):
     assert config.STATUS_UPDATE_INTERVAL == "1000"
 


### PR DESCRIPTION
### Purpose and background context

For local development, or external users of this application, it does not make sense to require a `SENTRY_DSN` environment variable.  While setting this to 'none' would satisfy the config setup, and not use Sentry, it feels unnecessary.

How this addresses that need:
* Moves `SENTRY_DSN` to optional env vars in `Config` class

NOTE: this PR ports the code changes from another PR https://github.com/MITLibraries/oai-pmh-harvester/pull/584 (thanks @cjwetherington!), which we were unable to merge at the time for unrelated CI/CD reasons.

### How can a reviewer manually see the effects of these changes?

1- unset `SENTRY_DSN` as environment variable

2- The following should show CLI help, where formerly this would throw a required env var error:
```shell
pipenv run oai --verbose \
-o /tmp/test.xml \
-h http://example.com \
harvest --help
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO: SENTRY_DSN is no longer required as an env var, but providing it will still get picked up used

### What are the relevant tickets?
- None

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed or provided examples verified
- [ ] New dependencies are appropriate or there were no changes
